### PR TITLE
Spelling fix "bellow" should be "below"

### DIFF
--- a/docs/Control-flow-with-block-and-message.html
+++ b/docs/Control-flow-with-block-and-message.html
@@ -193,7 +193,7 @@ are 4 control flow <code>#ifTrue:</code> messages. Each argument is a block of
 code and when evaluated, it explicitly returns an expression,
 therefore interrupting the method execution.
 </p>
-<p>In the code fragment of <a href="#shipLost">Example 5.6</a> bellow, we test if a ship is
+<p>In the code fragment of <a href="#shipLost">Example 5.6</a> below, we test if a ship is
 lost in deep space. It depends on two conditions:
 </p><ol>
 <li> the ship is out of the game play area, tested with the

--- a/docs/Events-_0028Solutions_0029.html
+++ b/docs/Events-_0028Solutions_0029.html
@@ -137,7 +137,7 @@ method in the <code>SpaceWar</code> class:
 
 <span id="secondShipControl-1"></span><h4 class="subheading"><a href="Spacewar_0021-Events.html#secondShipControl">Exercise 8.5</a></h4>
 <p>We designate the characters as <code>$w $a $s $d</code>. We append the
-code bellow to the method <code>SpaceWar&gt;&gt;keyStroke:</code>
+code below to the method <code>SpaceWar&gt;&gt;keyStroke:</code>
 </p><div class="example">
 <pre class="example">key = $w ifTrue: [^ ships second push].
 key = $d ifTrue: [^ ships second right].

--- a/docs/Fun-with-collections.html
+++ b/docs/Fun-with-collections.html
@@ -353,7 +353,7 @@ of prime numbers between 101 and 200.</em>
 <blockquote class="indentedblock">
 <p>&nbsp;<img src="CuisLogo.png" alt="CuisLogo">
 <em>Build the list of the
-multiples to 7 bellow 100.</em>
+multiples to 7 below 100.</em>
 </p></blockquote>
 
 

--- a/docs/Spacewar_0021_0027s-methods.html
+++ b/docs/Spacewar_0021_0027s-methods.html
@@ -121,7 +121,7 @@ class. Of course we need to use the System Browser:
 
 </li><li> In the <code>Method Category</code> pane, select the category
  <code>-- all --</code>. A method source code template shows up in the pane
- bellow:
+ below:
 <div class="example">
 <pre class="example">messageSelectorAndArgumentNames
   &quot;comment stating purpose of message&quot;

--- a/docs/String-_002d_002d-a-particular-collection.html
+++ b/docs/String-_002d_002d-a-particular-collection.html
@@ -180,7 +180,7 @@ element. When inherited in <code>String</code>, those elements are
 &rArr; $3
 </pre></div>
 
-<p>Practice the tools and resolve the exercise bellow.
+<p>Practice the tools and resolve the exercise below.
 </p>
 <div class="float"><span id="cutString"></span>
 <blockquote class="indentedblock">

--- a/docs/String.html
+++ b/docs/String.html
@@ -178,7 +178,7 @@ element. When inherited in <span class="sansserif">String</span>, those elements
 </span>
 </pre></div>
 
-<p>Practice the tools and resolve the exercise bellow.
+<p>Practice the tools and resolve the exercise below.
 </p>
 <div class="float"><span id="cutString"></span>
 <blockquote class="indentedblock">
@@ -189,7 +189,7 @@ method to transform &rsquo;Hello My Friend&rsquo; in &rsquo;My Friend&rsquo;?</e
 
 <div class="float-caption"><p><strong><em>Exercise</em> 4.1: </strong>Cut a string</p></div></div>
 <p>Beware, some messages in the <span class="sansserif">String</span> protocol may obviously not
-work. Observe bellow, the error is thrown on a <span class="sansserif">Character</span>
+work. Observe below, the error is thrown on a <span class="sansserif">Character</span>
 instance:
 </p>
 <div class="display">

--- a/docs/Writing-your-first-scripts.html
+++ b/docs/Writing-your-first-scripts.html
@@ -194,7 +194,7 @@ world!'</code>. We capitalize it with the <code>#capitalized</code> message:
 <span id="index-number"></span>
 <span id="index-keyboard-shortcut-2"></span>
 
-<p>In your Workspace, to compute a factorial execute the example bellow
+<p>In your Workspace, to compute a factorial execute the example below
 with <kbd>Ctrl-a</kbd> then <kbd>Ctrl-p</kbd> (<em><b>P</b>rint it</em>):
 </p><div class="example">
 <pre class="example">100 factorial
@@ -204,7 +204,7 @@ with <kbd>Ctrl-a</kbd> then <kbd>Ctrl-p</kbd> (<em><b>P</b>rint it</em>):
 </pre></div>
 
 <p>Cuis-Smalltalk handles very large integer numbers without requiring a
-special type declaration or method. To convince yourelf try the example bellow:
+special type declaration or method. To convince yourelf try the example below:
 </p><div class="example">
 <pre class="example">10000 factorial / 9999 factorial
 &rArr; 10000


### PR DESCRIPTION
Fix a spelling error on several pages. Note, "bellow" is a word in English (with different meaning) so a spell checker will not notice the mistake. The correct spelling is "below".