### PR TITLE
Use font-family: sans-serif

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -45,7 +45,7 @@ body
 {
 margin: 2% 7% 3% 7%;
 font-size: 100%;
-font-family: sans;
+font-family: sans-serif;
 text-align: justify;
 background: #FFFFFF;
 }

--- a/misc/christmasStyle.css
+++ b/misc/christmasStyle.css
@@ -50,7 +50,7 @@ body
 {
 margin: 2% 7% 3% 7%;
 font-size: 100%;
-font-family: sans;
+font-family: sans-serif;
 text-align: justify;
 background: black;
 color: lightgrey;

--- a/misc/style.css
+++ b/misc/style.css
@@ -45,7 +45,7 @@ body
 {
 margin: 2% 7% 3% 7%;
 font-size: 100%;
-font-family: sans;
+font-family: sans-serif;
 text-align: justify;
 background: #FFFFFF;
 }


### PR DESCRIPTION
Previously the font family was set to "sans" which is not a valid family.
Most browser use a serif font by default, so the desired effect didn't take
hold. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-family.