### PR TITLE
fix rogue t in code snippet

### DIFF
--- a/en/chapter-04/contents.texinfo
+++ b/en/chapter-04/contents.texinfo
@@ -864,7 +864,7 @@ change accordingly to the mechanical laws of physics.
 @smalltalkExampleCaption{Space ship mechanics, spaceShipMechanic,
 SpaceShip>>update: t
 "Update the ship position and velocity"
-   | ai ag newVelocity t |
+   | ai ag newVelocity |
    "acceleration vectors"
    ai @assign{} acceleration * self direction.
    ag @assign{} self gravity.


### PR DESCRIPTION
The code snippet for 'Example 4.19 Space ship mechanics' has an erroneous 't' in the local var declarations.