### PR TITLE
Fix preface typos

### DIFF
--- a/docs/A-Clock-Morph.html
+++ b/docs/A-Clock-Morph.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/A-brief-introduction-to-Inspectors.html
+++ b/docs/A-brief-introduction-to-Inspectors.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/A-brief-introduction-to-the-system-Browser.html
+++ b/docs/A-brief-introduction-to-the-system-Browser.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Back-to-Spacewar_0021-Morphs.html
+++ b/docs/Back-to-Spacewar_0021-Morphs.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Beginnings.html
+++ b/docs/Beginnings.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Block-syntax.html
+++ b/docs/Block-syntax.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Building-your-specialized-Morph.html
+++ b/docs/Building-your-specialized-Morph.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Class-_002d-Model-of-Communicating-Entities.html
+++ b/docs/Class-_002d-Model-of-Communicating-Entities.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Class-_002d_002d-model-of-Communicating-Entities-_0028Solutions_0029.html
+++ b/docs/Class-_002d_002d-model-of-Communicating-Entities-_0028Solutions_0029.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 
@@ -61,7 +61,7 @@ Complete license: https://creativecommons.org/licenses/by-sa/4.0/legalcode
 <meta name="Generator" content="texi2any">
 <link href="index.html" rel="start" title="Top">
 <link href="Indexes.html" rel="index" title="Indexes">
-<link href="Solutions-of-the-Exercises.html" rel="up" title="Solutions of the Exercises">
+<link href="Solutions-to-the-Exercises.html" rel="up" title="Solutions to the Exercises">
 <link href="The-Collection-Way-of-Life-_0028Solutions_0029.html" rel="next" title="The Collection Way of Life (Solutions)">
 <link href="The-Message-Way-of-Life-_0028Solutions_0029.html" rel="prev" title="The Message Way of Life (Solutions)">
 <style type="text/css">
@@ -90,7 +90,7 @@ ul.no-bullet {list-style: none}
 <body lang="en">
 <span id="Class-_002d_002d-model-of-Communicating-Entities-_0028Solutions_0029"></span><div class="header">
 <p>
-Next: <a href="The-Collection-Way-of-Life-_0028Solutions_0029.html" accesskey="n" rel="next">The Collection Way of Life (Solutions)</a>, Previous: <a href="The-Message-Way-of-Life-_0028Solutions_0029.html" accesskey="p" rel="prev">The Message Way of Life (Solutions)</a>, Up: <a href="Solutions-of-the-Exercises.html" accesskey="u" rel="up">Solutions of the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
+Next: <a href="The-Collection-Way-of-Life-_0028Solutions_0029.html" accesskey="n" rel="next">The Collection Way of Life (Solutions)</a>, Previous: <a href="The-Message-Way-of-Life-_0028Solutions_0029.html" accesskey="p" rel="prev">The Message Way of Life (Solutions)</a>, Up: <a href="Solutions-to-the-Exercises.html" accesskey="u" rel="up">Solutions to the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
 </div>
 <hr>
 <span id="Class_002c-model-of-Communicating-Entities"></span><h3 class="unnumberedsec">Class, model of Communicating Entities</h3>
@@ -257,7 +257,7 @@ SpaceShip&gt;&gt;unpush
 <hr>
 <div class="header">
 <p>
-Next: <a href="The-Collection-Way-of-Life-_0028Solutions_0029.html" accesskey="n" rel="next">The Collection Way of Life (Solutions)</a>, Previous: <a href="The-Message-Way-of-Life-_0028Solutions_0029.html" accesskey="p" rel="prev">The Message Way of Life (Solutions)</a>, Up: <a href="Solutions-of-the-Exercises.html" accesskey="u" rel="up">Solutions of the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
+Next: <a href="The-Collection-Way-of-Life-_0028Solutions_0029.html" accesskey="n" rel="next">The Collection Way of Life (Solutions)</a>, Previous: <a href="The-Message-Way-of-Life-_0028Solutions_0029.html" accesskey="p" rel="prev">The Message Way of Life (Solutions)</a>, Up: <a href="Solutions-to-the-Exercises.html" accesskey="u" rel="up">Solutions to the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
 </div>
 
 

--- a/docs/Code-Management-_0028Solutions_0029.html
+++ b/docs/Code-Management-_0028Solutions_0029.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 
@@ -61,7 +61,7 @@ Complete license: https://creativecommons.org/licenses/by-sa/4.0/legalcode
 <meta name="Generator" content="texi2any">
 <link href="index.html" rel="start" title="Top">
 <link href="Indexes.html" rel="index" title="Indexes">
-<link href="Solutions-of-the-Exercises.html" rel="up" title="Solutions of the Exercises">
+<link href="Solutions-to-the-Exercises.html" rel="up" title="Solutions to the Exercises">
 <link href="The-Examples.html" rel="next" title="The Examples">
 <link href="Events-_0028Solutions_0029.html" rel="prev" title="Events (Solutions)">
 <style type="text/css">
@@ -90,7 +90,7 @@ ul.no-bullet {list-style: none}
 <body lang="en">
 <span id="Code-Management-_0028Solutions_0029"></span><div class="header">
 <p>
-Previous: <a href="Events-_0028Solutions_0029.html" accesskey="p" rel="prev">Events (Solutions)</a>, Up: <a href="Solutions-of-the-Exercises.html" accesskey="u" rel="up">Solutions of the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
+Previous: <a href="Events-_0028Solutions_0029.html" accesskey="p" rel="prev">Events (Solutions)</a>, Up: <a href="Solutions-to-the-Exercises.html" accesskey="u" rel="up">Solutions to the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
 </div>
 <hr>
 <span id="Code-Management-2"></span><h3 class="unnumberedsec">Code Management</h3>

--- a/docs/Code-Management.html
+++ b/docs/Code-Management.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Collections-detailed.html
+++ b/docs/Collections-detailed.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Communicating-entities.html
+++ b/docs/Communicating-entities.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Control-Flow-Messaging-_0028Solutions_0029.html
+++ b/docs/Control-Flow-Messaging-_0028Solutions_0029.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 
@@ -61,7 +61,7 @@ Complete license: https://creativecommons.org/licenses/by-sa/4.0/legalcode
 <meta name="Generator" content="texi2any">
 <link href="index.html" rel="start" title="Top">
 <link href="Indexes.html" rel="index" title="Indexes">
-<link href="Solutions-of-the-Exercises.html" rel="up" title="Solutions of the Exercises">
+<link href="Solutions-to-the-Exercises.html" rel="up" title="Solutions to the Exercises">
 <link href="Visual-with-Morph-_0028Solutions_0029.html" rel="next" title="Visual with Morph (Solutions)">
 <link href="The-Collection-Way-of-Life-_0028Solutions_0029.html" rel="prev" title="The Collection Way of Life (Solutions)">
 <style type="text/css">
@@ -90,7 +90,7 @@ ul.no-bullet {list-style: none}
 <body lang="en">
 <span id="Control-Flow-Messaging-_0028Solutions_0029"></span><div class="header">
 <p>
-Next: <a href="Visual-with-Morph-_0028Solutions_0029.html" accesskey="n" rel="next">Visual with Morph (Solutions)</a>, Previous: <a href="The-Collection-Way-of-Life-_0028Solutions_0029.html" accesskey="p" rel="prev">The Collection Way of Life (Solutions)</a>, Up: <a href="Solutions-of-the-Exercises.html" accesskey="u" rel="up">Solutions of the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
+Next: <a href="Visual-with-Morph-_0028Solutions_0029.html" accesskey="n" rel="next">Visual with Morph (Solutions)</a>, Previous: <a href="The-Collection-Way-of-Life-_0028Solutions_0029.html" accesskey="p" rel="prev">The Collection Way of Life (Solutions)</a>, Up: <a href="Solutions-to-the-Exercises.html" accesskey="u" rel="up">Solutions to the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
 </div>
 <hr>
 <span id="Control-Flow-Messaging-2"></span><h3 class="unnumberedsec">Control Flow Messaging</h3>
@@ -159,7 +159,7 @@ referenced exercise and examples.
 <hr>
 <div class="header">
 <p>
-Next: <a href="Visual-with-Morph-_0028Solutions_0029.html" accesskey="n" rel="next">Visual with Morph (Solutions)</a>, Previous: <a href="The-Collection-Way-of-Life-_0028Solutions_0029.html" accesskey="p" rel="prev">The Collection Way of Life (Solutions)</a>, Up: <a href="Solutions-of-the-Exercises.html" accesskey="u" rel="up">Solutions of the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
+Next: <a href="Visual-with-Morph-_0028Solutions_0029.html" accesskey="n" rel="next">Visual with Morph (Solutions)</a>, Previous: <a href="The-Collection-Way-of-Life-_0028Solutions_0029.html" accesskey="p" rel="prev">The Collection Way of Life (Solutions)</a>, Up: <a href="Solutions-to-the-Exercises.html" accesskey="u" rel="up">Solutions to the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
 </div>
 
 

--- a/docs/Control-Flow-Messaging.html
+++ b/docs/Control-Flow-Messaging.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Control-flow-with-block-and-message.html
+++ b/docs/Control-flow-with-block-and-message.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Cuis-system-classes.html
+++ b/docs/Cuis-system-classes.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Daily-Workflow.html
+++ b/docs/Daily-Workflow.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Debug-and-Exception-Handling.html
+++ b/docs/Debug-and-Exception-Handling.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Documents-Copyright.html
+++ b/docs/Documents-Copyright.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/E_002dexeRectMorph.html
+++ b/docs/E_002dexeRectMorph.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/E_002dexeRotateRect1.html
+++ b/docs/E_002dexeRotateRect1.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/E_002dexeRotateRect2.html
+++ b/docs/E_002dexeRotateRect2.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/E_002dimg1.html
+++ b/docs/E_002dimg1.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Ellipse-Morph.html
+++ b/docs/Ellipse-Morph.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Events-_0028Solutions_0029.html
+++ b/docs/Events-_0028Solutions_0029.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 
@@ -61,7 +61,7 @@ Complete license: https://creativecommons.org/licenses/by-sa/4.0/legalcode
 <meta name="Generator" content="texi2any">
 <link href="index.html" rel="start" title="Top">
 <link href="Indexes.html" rel="index" title="Indexes">
-<link href="Solutions-of-the-Exercises.html" rel="up" title="Solutions of the Exercises">
+<link href="Solutions-to-the-Exercises.html" rel="up" title="Solutions to the Exercises">
 <link href="Code-Management-_0028Solutions_0029.html" rel="next" title="Code Management (Solutions)">
 <link href="The-Fundamentals-of-Morph-_0028Solutions_0029.html" rel="prev" title="The Fundamentals of Morph (Solutions)">
 <style type="text/css">
@@ -90,7 +90,7 @@ ul.no-bullet {list-style: none}
 <body lang="en">
 <span id="Events-_0028Solutions_0029"></span><div class="header">
 <p>
-Next: <a href="Code-Management-_0028Solutions_0029.html" accesskey="n" rel="next">Code Management (Solutions)</a>, Previous: <a href="The-Fundamentals-of-Morph-_0028Solutions_0029.html" accesskey="p" rel="prev">The Fundamentals of Morph (Solutions)</a>, Up: <a href="Solutions-of-the-Exercises.html" accesskey="u" rel="up">Solutions of the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
+Next: <a href="Code-Management-_0028Solutions_0029.html" accesskey="n" rel="next">Code Management (Solutions)</a>, Previous: <a href="The-Fundamentals-of-Morph-_0028Solutions_0029.html" accesskey="p" rel="prev">The Fundamentals of Morph (Solutions)</a>, Up: <a href="Solutions-to-the-Exercises.html" accesskey="u" rel="up">Solutions to the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
 </div>
 <hr>
 <span id="Events-2"></span><h3 class="unnumberedsec">Events</h3>

--- a/docs/Events.html
+++ b/docs/Events.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Explore-OOP-from-the-Browser.html
+++ b/docs/Explore-OOP-from-the-Browser.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/FloatPrecision.html
+++ b/docs/FloatPrecision.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/FractionPrecision.html
+++ b/docs/FractionPrecision.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Fun-with-collections.html
+++ b/docs/Fun-with-collections.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Fun-with-variables.html
+++ b/docs/Fun-with-variables.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Going-Vector.html
+++ b/docs/Going-Vector.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 
@@ -335,7 +335,7 @@ around its center.</em>
 
 
 <div class="float-caption"><p><strong>Exercise 7.3: </strong>Rotate your rectangle morph arround its center</p></div></div>
-<p>In the solution we gave for the <a href="#exeCrossMorph">Exercise 7.1</a> (<a href="Solutions-of-the-Exercises.html">Solutions of the Exercises</a>), the cross origin is set to its top left. Therefore it
+<p>In the solution we gave for the <a href="#exeCrossMorph">Exercise 7.1</a> (<a href="Solutions-to-the-Exercises.html">Solutions to the Exercises</a>), the cross origin is set to its top left. Therefore it
 rotates around this point.
 </p>
 <div class="float"><span id="exeCrossCenterMorph"></span>

--- a/docs/Golden-Rules-of-the-Smalltalk-Guild.html
+++ b/docs/Golden-Rules-of-the-Smalltalk-Guild.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Halt_0021.html
+++ b/docs/Halt_0021.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Historical-Context.html
+++ b/docs/Historical-Context.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Indexes.html
+++ b/docs/Indexes.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Inspecting-the-Unexpected.html
+++ b/docs/Inspecting-the-Unexpected.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Installing-a-Package.html
+++ b/docs/Installing-a-Package.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Installing-and-configuring-Cuis_002dSmalltalk.html
+++ b/docs/Installing-and-configuring-Cuis_002dSmalltalk.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Kernel_002dNumbers.html
+++ b/docs/Kernel_002dNumbers.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Kernel_002dText.html
+++ b/docs/Kernel_002dText.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Message-send-definitions.html
+++ b/docs/Message-send-definitions.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Message-to-string-entities.html
+++ b/docs/Message-to-string-entities.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Messages-to-number-entities.html
+++ b/docs/Messages-to-number-entities.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Method-syntax.html
+++ b/docs/Method-syntax.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Overall-Mechanism.html
+++ b/docs/Overall-Mechanism.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Preface-_0028Solutions_0029.html
+++ b/docs/Preface-_0028Solutions_0029.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 
@@ -61,9 +61,9 @@ Complete license: https://creativecommons.org/licenses/by-sa/4.0/legalcode
 <meta name="Generator" content="texi2any">
 <link href="index.html" rel="start" title="Top">
 <link href="Indexes.html" rel="index" title="Indexes">
-<link href="Solutions-of-the-Exercises.html" rel="up" title="Solutions of the Exercises">
+<link href="Solutions-to-the-Exercises.html" rel="up" title="Solutions to the Exercises">
 <link href="Smallltalk-Philosophy-_0028Solutions_0029.html" rel="next" title="Smallltalk Philosophy (Solutions)">
-<link href="Solutions-of-the-Exercises.html" rel="prev" title="Solutions of the Exercises">
+<link href="Solutions-to-the-Exercises.html" rel="prev" title="Solutions to the Exercises">
 <style type="text/css">
 <!--
 a.summary-letter {text-decoration: none}
@@ -90,7 +90,7 @@ ul.no-bullet {list-style: none}
 <body lang="en">
 <span id="Preface-_0028Solutions_0029"></span><div class="header">
 <p>
-Next: <a href="Smallltalk-Philosophy-_0028Solutions_0029.html" accesskey="n" rel="next">Smallltalk Philosophy (Solutions)</a>, Up: <a href="Solutions-of-the-Exercises.html" accesskey="u" rel="up">Solutions of the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
+Next: <a href="Smallltalk-Philosophy-_0028Solutions_0029.html" accesskey="n" rel="next">Smallltalk Philosophy (Solutions)</a>, Up: <a href="Solutions-to-the-Exercises.html" accesskey="u" rel="up">Solutions to the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
 </div>
 <hr>
 <span id="Preface-2"></span><h3 class="unnumberedsec">Preface</h3>

--- a/docs/Preface.html
+++ b/docs/Preface.html
@@ -213,7 +213,7 @@ can be used as a reference elsewhere in the book:
 <p>There are also a lot of exercises. Most are very easy; they intend to give you
 an opportunity to apply what you have just learned.
 </p>
-<p>Exercises are easily identified with the Cuis-Smalltalk mascot: <em>Cuis</em>,
+<p>Exercises are easily identified by the Cuis-Smalltalk mascot: <em>Cuis</em>,
 a South American rodent!
 </p>
 <div class="float"><span id="exerciseExample"></span>

--- a/docs/Preface.html
+++ b/docs/Preface.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 
@@ -112,13 +112,13 @@ is, and what it means to build software. As a consequence, Cuis is
 especially effective if these ideas resonate with you and, at least
 occasionally, you let them guide your thoughts and actions.
 </p>
-<p>In this book, we will go along with you as you explore, discover and
+<p>In this book, we will accompany you as you explore, discover and
 learn about Cuis and Smalltalk.
 </p>
 <p>We don&rsquo;t assume knowledge of computer programming, but if you happen
-to have some experience with an Object Oriented or Functional language
+to have some experience with an Object-Oriented or Functional language
 you will recognize many concepts. If you don&rsquo;t have any programming
-experience, or you have coded in an imperative, closer to the metal
+experience or you have coded in an imperative, closer to the metal
 language, such as C or Assembly, many of the ideas may be new.
 </p>
 <p>In any case, especially during the first chapters, read this book and
@@ -129,19 +129,18 @@ programming is a thoughtful process.
 <p>We understand software development as the activity of learning and
 documenting knowledge for ourselves and others to use, and also to be
 run on a computer. The fact that a computer can execute the software
-and produce useful solutions to some problem, is a consequence of the
+and produce useful solutions to some problem is a consequence of the
 knowledge being sound and relevant. Just making it work is not the
 important part!
 </p>
-<p>These ideas, that will be developed further along in the book you are
-reading, strongly shape Cuis and the experience of using it.  Amongst
-their most obvious consequences are a passion for reducing unneeded
-complexity, while providing a complete, live software development
-experience.
+<p>These ideas strongly shape Cuis and the experience of using it, and
+we&rsquo;ll develop them further along in this book.  Amongst their most
+obvious consequences are a passion for reducing unneeded complexity,
+while providing a complete, live software development experience.
 </p>
 <p>This book is an introduction and invitation to explore Cuis.  We hope
 you will join us in this journey to use Cuis as a medium to express
-ideas and thoughts, to build cool stuff, and to make Cuis ever better.
+ideas and thoughts, to build cool stuff, and to make Cuis even better.
 </p>
 <div class="float"><span id="ch00_002dimg1"></span>
 <div align="center"><img src="ch00-img1.png" alt="ch00-img1">
@@ -149,7 +148,7 @@ ideas and thoughts, to build cool stuff, and to make Cuis ever better.
 <div class="float-caption"><p><strong>Figure 1: </strong>Cuis</p></div></div>
 <p>To make your journey with this book more enjoyable, the
 <em>Spacewar!</em><a id="DOCF1" href="#FOOT1"><sup>1</sup></a>
-project is its recurring theme. It is distilled along the book in code
+project is its recurring theme. It is distilled into the book in code
 examples, exercises and dedicated chapters. At the end of the book,
 you will have written a replica of this historic video game.
 </p>
@@ -159,37 +158,39 @@ you will have written a replica of this historic video game.
 <p>The reader can study Cuis-Smalltalk from two versions of the book:
 </p>
 <ul>
-<li> <strong>Online.</strong> With a web browser at the
+<li> <strong>Online:</strong> With a web browser at the
  <a href="https://cuis-smalltalk.github.io/TheCuisBook">https://cuis-smalltalk.github.io/TheCuisBook</a> address. The book
  is structured in chapters and sections, displayed one at a time. It
  is a very flexible way to study the book: you can open several
  chapters and appendices on different tabs in your web browser. It
  requires you to be connected to the Internet, though.
 
-</li><li> <strong>Offline.</strong> It is a PDF version coming in one file you
- download and read offline. It can be printed as a nice paper
- book. Its most recent build is found at
- <a href="https://github.com/Cuis-Smalltalk/TheCuisBook">https://github.com/Cuis-Smalltalk/TheCuisBook</a>.
+</li><li> <strong>Offline:</strong> In a single PDF file you download and read
+ offline. It can be printed as a nice paper book. The most recent
+ build can be found at <a href="https://github.com/Cuis-Smalltalk/TheCuisBook">https://github.com/Cuis-Smalltalk/TheCuisBook</a>.
 
 </li></ul>
 
 <span id="index-returned-value"></span>
 <span id="index-variable"></span>
+
+<p>The chapters come with many examples. Some can be copied and pasted into
+Cuis-Smalltalk. We encourage you to do this, and in the process modify them
+to explore on your own.
+</p>
 <p>The code examples in the online version can be directly copied and
 pasted into Cuis-Smalltalk. This is why the assignment character &ldquo;&#x2190;&rdquo;
 you see in the developer Cuis-Smalltalk window is printed as &ldquo;:=&rdquo; in the
 online version of the book. The same applies with the return character
 &ldquo;&#x2191;&rdquo; printed as &ldquo;^&rdquo; in the online version.
 </p>
-<p>In the offline PDF version, the code example are printed with the same
- assignment and return characters as seen in the Cuis-Smalltalk
- windows. Coping and pasting also work as expected.
+<p>In the offline PDF version, the code examples are printed with the same
+assignment and return characters as seen in the Cuis-Smalltalk windows. Copying
+and pasting also work as expected.
 </p>
-<p>The chapters come with many of examples. Some can be copied and
-pasted in Cuis-Smalltalk, we encourage you to do this, and in the process
-modify them to explore by yourself. Other examples are code extracts
-which are not self sufficient to be executed as is; their purpose is
-to expose specific facets of the Smalltalk language.
+<p>Other examples are code extracts which are not self sufficient to be
+executed as is. Their purpose is to expose specific facets of the Smalltalk
+language.
 </p>
 <p>A typical example without a caption looks like:
 </p>
@@ -197,7 +198,7 @@ to expose specific facets of the Smalltalk language.
 <pre class="example">100 factorial
 </pre></div>
 
-<p>The same example with a caption comes with a number, a legend and it
+<p>The same example with a caption appears with a number and title, and
 can be used as a reference elsewhere in the book:
 </p>
 <div class="float"><span id="exampleExample"></span>
@@ -208,13 +209,12 @@ can be used as a reference elsewhere in the book:
 51185210916864000000000000000000000000
 </pre></div>
 
-<div class="float-caption"><p><strong>Example 1: </strong>I am an example with a caption and result</p></div></div>
-<p>There are also a lot of exercises. Most are very
-easy, their intent is to give you an opportunity to apply what was
-learned just before. The solution can be read in the appendix.
+<div class="float-caption"><p><strong>Example 1: </strong>I am an example with a caption and a result</p></div></div>
+<p>There are also a lot of exercises. Most are very easy; they intend to give you
+an opportunity to apply what you have just learned.
 </p>
-<p>Exercises are easily identified, there are presented by the Cuis-Smalltalk
-mascot: <em>Cuis</em>, a South American rodent!
+<p>Exercises are easily identified with the Cuis-Smalltalk mascot: <em>Cuis</em>,
+a South American rodent!
 </p>
 <div class="float"><span id="exerciseExample"></span>
 <blockquote class="indentedblock">
@@ -224,7 +224,7 @@ mascot: <em>Cuis</em>, a South American rodent!
 
 
 <div class="float-caption"><p><strong>Exercise 1: </strong>I am an example of an exercise</p></div></div>
-<p>The solution of the exercises are presented in <a href="Solutions-of-the-Exercises.html">Solutions of the Exercises</a>.
+<p>The solutions to the exercises are presented in <a href="Solutions-to-the-Exercises.html">Solutions to the Exercises</a>.
 </p>
 <p>Happy reading!
 </p><div class="footnote">

--- a/docs/Pseudo_002dvariables.html
+++ b/docs/Pseudo_002dvariables.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Refactoring-to-Improve-Understanding.html
+++ b/docs/Refactoring-to-Improve-Understanding.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Sharing-Cuis.html
+++ b/docs/Sharing-Cuis.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Smallltalk-Philosophy-_0028Solutions_0029.html
+++ b/docs/Smallltalk-Philosophy-_0028Solutions_0029.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 
@@ -61,7 +61,7 @@ Complete license: https://creativecommons.org/licenses/by-sa/4.0/legalcode
 <meta name="Generator" content="texi2any">
 <link href="index.html" rel="start" title="Top">
 <link href="Indexes.html" rel="index" title="Indexes">
-<link href="Solutions-of-the-Exercises.html" rel="up" title="Solutions of the Exercises">
+<link href="Solutions-to-the-Exercises.html" rel="up" title="Solutions to the Exercises">
 <link href="The-Message-Way-of-Life-_0028Solutions_0029.html" rel="next" title="The Message Way of Life (Solutions)">
 <link href="Preface-_0028Solutions_0029.html" rel="prev" title="Preface (Solutions)">
 <style type="text/css">
@@ -90,7 +90,7 @@ ul.no-bullet {list-style: none}
 <body lang="en">
 <span id="Smallltalk-Philosophy-_0028Solutions_0029"></span><div class="header">
 <p>
-Next: <a href="The-Message-Way-of-Life-_0028Solutions_0029.html" accesskey="n" rel="next">The Message Way of Life (Solutions)</a>, Previous: <a href="Preface-_0028Solutions_0029.html" accesskey="p" rel="prev">Preface (Solutions)</a>, Up: <a href="Solutions-of-the-Exercises.html" accesskey="u" rel="up">Solutions of the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
+Next: <a href="The-Message-Way-of-Life-_0028Solutions_0029.html" accesskey="n" rel="next">The Message Way of Life (Solutions)</a>, Previous: <a href="Preface-_0028Solutions_0029.html" accesskey="p" rel="prev">Preface (Solutions)</a>, Up: <a href="Solutions-to-the-Exercises.html" accesskey="u" rel="up">Solutions to the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
 </div>
 <hr>
 <span id="Smallltalk-Philosophy"></span><h3 class="unnumberedsec">Smallltalk Philosophy</h3>

--- a/docs/Solutions-to-the-Exercises.html
+++ b/docs/Solutions-to-the-Exercises.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<!-- This book is for Cuis-Smalltalk (5.0#4506), a free and modern
+implementation of the Smalltalk language and environment.
+
+Copyright (C) 2020 Hilaire Fernandes with Ken Dickey & Juan Vuletich
+
+
+Thanks to Matt Armstrong, David Lewis, Tommy Pettersson & Mauro Rizzi
+for the reviews of the book and suggestions to improve it.
+
+
+
+
+
+Compilation : May 13, 2021
+
+Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
+
+
+
+The contents of this book are protected under Creative Commons
+Attribution-ShareAlike 4.0 International.
+
+You are free to:
+
+
+Share - copy and redistribute the material in any medium or
+format
+
+
+Adapt - remix, transform, and build upon the material for any
+purpose, even commercially.
+
+
+
+Under the following terms:
+
+
+Attribution. You must give appropriate credit, provide a link to
+the license, and indicate if changes were made. You may do so in any
+reasonable manner, but not in any way that suggests the licensor
+endorses you or your use.
+
+
+Share Alike. If you remix, transform, or build upon the material,
+you must distribute your contributions under the same license as the
+original.
+
+Complete license: https://creativecommons.org/licenses/by-sa/4.0/legalcode
+ -->
+<!-- Created by GNU Texinfo 6.7, http://www.gnu.org/software/texinfo/ -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<title>Solutions to the Exercises (The Cuis-Smalltalk Book)</title>
+
+<meta name="description" content="Solutions to the Exercises (The Cuis-Smalltalk Book)">
+<meta name="keywords" content="Solutions to the Exercises (The Cuis-Smalltalk Book)">
+<meta name="resource-type" content="document">
+<meta name="distribution" content="global">
+<meta name="Generator" content="texi2any">
+<link href="index.html" rel="start" title="Top">
+<link href="Indexes.html" rel="index" title="Indexes">
+<link href="index.html" rel="up" title="Top">
+<link href="Preface-_0028Solutions_0029.html" rel="next" title="Preface (Solutions)">
+<link href="The-Exercises.html" rel="prev" title="The Exercises">
+<style type="text/css">
+<!--
+a.summary-letter {text-decoration: none}
+blockquote.indentedblock {margin-right: 0em}
+div.display {margin-left: 3.2em}
+div.example {margin-left: 3.2em}
+div.lisp {margin-left: 3.2em}
+kbd {font-style: oblique}
+pre.display {font-family: inherit}
+pre.format {font-family: inherit}
+pre.menu-comment {font-family: serif}
+pre.menu-preformatted {font-family: serif}
+span.nolinebreak {white-space: nowrap}
+span.roman {font-family: initial; font-weight: normal}
+span.sansserif {font-family: sans-serif; font-weight: normal}
+ul.no-bullet {list-style: none}
+-->
+</style>
+<link rel="stylesheet" type="text/css" href="style.css">
+
+
+</head>
+
+<body lang="en">
+<span id="Solutions-to-the-Exercises"></span><div class="header">
+<p>
+Next: <a href="The-Examples.html" accesskey="n" rel="next">The Examples</a>, Previous: <a href="The-Exercises.html" accesskey="p" rel="prev">The Exercises</a>, Up: <a href="index.html" accesskey="u" rel="up">Top</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
+</div>
+<hr>
+<span id="Solutions-to-the-Exercises-1"></span><h2 class="appendix">Appendix D Solutions to the Exercises</h2>
+
+
+<table class="menu" border="0" cellspacing="0">
+<tr><td align="left" valign="top">&bull; <a href="Preface-_0028Solutions_0029.html" accesskey="1">Preface (Solutions)</a></td><td>&nbsp;&nbsp;</td><td align="left" valign="top">
+</td></tr>
+<tr><td align="left" valign="top">&bull; <a href="Smallltalk-Philosophy-_0028Solutions_0029.html" accesskey="2">Smallltalk Philosophy (Solutions)</a></td><td>&nbsp;&nbsp;</td><td align="left" valign="top">
+</td></tr>
+<tr><td align="left" valign="top">&bull; <a href="The-Message-Way-of-Life-_0028Solutions_0029.html" accesskey="3">The Message Way of Life (Solutions)</a></td><td>&nbsp;&nbsp;</td><td align="left" valign="top">
+</td></tr>
+<tr><td align="left" valign="top">&bull; <a href="Class-_002d_002d-model-of-Communicating-Entities-_0028Solutions_0029.html" accesskey="4">Class -- model of Communicating Entities (Solutions)</a></td><td>&nbsp;&nbsp;</td><td align="left" valign="top">
+</td></tr>
+<tr><td align="left" valign="top">&bull; <a href="The-Collection-Way-of-Life-_0028Solutions_0029.html" accesskey="5">The Collection Way of Life (Solutions)</a></td><td>&nbsp;&nbsp;</td><td align="left" valign="top">
+</td></tr>
+<tr><td align="left" valign="top">&bull; <a href="Control-Flow-Messaging-_0028Solutions_0029.html" accesskey="6">Control Flow Messaging (Solutions)</a></td><td>&nbsp;&nbsp;</td><td align="left" valign="top">
+</td></tr>
+<tr><td align="left" valign="top">&bull; <a href="Visual-with-Morph-_0028Solutions_0029.html" accesskey="7">Visual with Morph (Solutions)</a></td><td>&nbsp;&nbsp;</td><td align="left" valign="top">
+</td></tr>
+<tr><td align="left" valign="top">&bull; <a href="The-Fundamentals-of-Morph-_0028Solutions_0029.html" accesskey="8">The Fundamentals of Morph (Solutions)</a></td><td>&nbsp;&nbsp;</td><td align="left" valign="top">
+</td></tr>
+<tr><td align="left" valign="top">&bull; <a href="Events-_0028Solutions_0029.html" accesskey="9">Events (Solutions)</a></td><td>&nbsp;&nbsp;</td><td align="left" valign="top">
+</td></tr>
+<tr><td align="left" valign="top">&bull; <a href="Code-Management-_0028Solutions_0029.html">Code Management (Solutions)</a></td><td>&nbsp;&nbsp;</td><td align="left" valign="top">
+</td></tr>
+</table>
+
+
+
+
+
+
+</body>
+</html>

--- a/docs/SpaceWar_0021-collections.html
+++ b/docs/SpaceWar_0021-collections.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Spacewar_0021-Events.html
+++ b/docs/Spacewar_0021-Events.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Spacewar_0021-Morphs.html
+++ b/docs/Spacewar_0021-Morphs.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Spacewar_0021-States-and-Behaviors.html
+++ b/docs/Spacewar_0021-States-and-Behaviors.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Spacewar_0021-models.html
+++ b/docs/Spacewar_0021-models.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Spacewar_0021-package.html
+++ b/docs/Spacewar_0021-package.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Spacewar_0021.html
+++ b/docs/Spacewar_0021.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Spacewar_0021_0027s-methods.html
+++ b/docs/Spacewar_0021_0027s-methods.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/String-_002d_002d-a-particular-collection.html
+++ b/docs/String-_002d_002d-a-particular-collection.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Submorph.html
+++ b/docs/Submorph.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Summary-of-Syntax.html
+++ b/docs/Summary-of-Syntax.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Syntactic-elements.html
+++ b/docs/Syntactic-elements.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/System-Events.html
+++ b/docs/System-Events.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/The-Change-Log.html
+++ b/docs/The-Change-Log.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/The-Change-Set.html
+++ b/docs/The-Change-Set.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/The-Collection-Way-of-Life-_0028Solutions_0029.html
+++ b/docs/The-Collection-Way-of-Life-_0028Solutions_0029.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 
@@ -61,7 +61,7 @@ Complete license: https://creativecommons.org/licenses/by-sa/4.0/legalcode
 <meta name="Generator" content="texi2any">
 <link href="index.html" rel="start" title="Top">
 <link href="Indexes.html" rel="index" title="Indexes">
-<link href="Solutions-of-the-Exercises.html" rel="up" title="Solutions of the Exercises">
+<link href="Solutions-to-the-Exercises.html" rel="up" title="Solutions to the Exercises">
 <link href="Control-Flow-Messaging-_0028Solutions_0029.html" rel="next" title="Control Flow Messaging (Solutions)">
 <link href="Class-_002d_002d-model-of-Communicating-Entities-_0028Solutions_0029.html" rel="prev" title="Class -- model of Communicating Entities (Solutions)">
 <style type="text/css">
@@ -90,7 +90,7 @@ ul.no-bullet {list-style: none}
 <body lang="en">
 <span id="The-Collection-Way-of-Life-_0028Solutions_0029"></span><div class="header">
 <p>
-Next: <a href="Control-Flow-Messaging-_0028Solutions_0029.html" accesskey="n" rel="next">Control Flow Messaging (Solutions)</a>, Previous: <a href="Class-_002d_002d-model-of-Communicating-Entities-_0028Solutions_0029.html" accesskey="p" rel="prev">Class -- model of Communicating Entities (Solutions)</a>, Up: <a href="Solutions-of-the-Exercises.html" accesskey="u" rel="up">Solutions of the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
+Next: <a href="Control-Flow-Messaging-_0028Solutions_0029.html" accesskey="n" rel="next">Control Flow Messaging (Solutions)</a>, Previous: <a href="Class-_002d_002d-model-of-Communicating-Entities-_0028Solutions_0029.html" accesskey="p" rel="prev">Class -- model of Communicating Entities (Solutions)</a>, Up: <a href="Solutions-to-the-Exercises.html" accesskey="u" rel="up">Solutions to the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
 </div>
 <hr>
 <span id="The-Collection-Way-of-Life-2"></span><h3 class="unnumberedsec">The Collection Way of Life</h3>
@@ -275,7 +275,7 @@ appropriate indentation.
 <hr>
 <div class="header">
 <p>
-Next: <a href="Control-Flow-Messaging-_0028Solutions_0029.html" accesskey="n" rel="next">Control Flow Messaging (Solutions)</a>, Previous: <a href="Class-_002d_002d-model-of-Communicating-Entities-_0028Solutions_0029.html" accesskey="p" rel="prev">Class -- model of Communicating Entities (Solutions)</a>, Up: <a href="Solutions-of-the-Exercises.html" accesskey="u" rel="up">Solutions of the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
+Next: <a href="Control-Flow-Messaging-_0028Solutions_0029.html" accesskey="n" rel="next">Control Flow Messaging (Solutions)</a>, Previous: <a href="Class-_002d_002d-model-of-Communicating-Entities-_0028Solutions_0029.html" accesskey="p" rel="prev">Class -- model of Communicating Entities (Solutions)</a>, Up: <a href="Solutions-to-the-Exercises.html" accesskey="u" rel="up">Solutions to the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
 </div>
 
 

--- a/docs/The-Collection-Way-of-Life.html
+++ b/docs/The-Collection-Way-of-Life.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/The-Debugger.html
+++ b/docs/The-Debugger.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/The-Examples.html
+++ b/docs/The-Examples.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 
@@ -90,12 +90,12 @@ ul.no-bullet {list-style: none}
 <body lang="en">
 <span id="The-Examples"></span><div class="header">
 <p>
-Next: <a href="The-Figures.html" accesskey="n" rel="next">The Figures</a>, Previous: <a href="Solutions-of-the-Exercises.html" accesskey="p" rel="prev">Solutions of the Exercises</a>, Up: <a href="index.html" accesskey="u" rel="up">Top</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
+Next: <a href="The-Figures.html" accesskey="n" rel="next">The Figures</a>, Previous: <a href="Solutions-to-the-Exercises.html" accesskey="p" rel="prev">Solutions to the Exercises</a>, Up: <a href="index.html" accesskey="u" rel="up">Top</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
 </div>
 <hr>
 <span id="The-Examples-1"></span><h2 class="appendix">Appendix E The Examples</h2>
 <dl class="listoffloats">
-<dt><a href="Preface.html#exampleExample">Example 1</a></dt><dd><p>I am an example with a caption and result</p></dd>
+<dt><a href="Preface.html#exampleExample">Example 1</a></dt><dd><p>I am an example with a caption and a result</p></dd>
 <dt><a href="Writing-your-first-scripts.html#hello">Example 1.1</a></dt><dd><p>The traditional &rsquo;Hello World!&rsquo; program</p></dd>
 <dt><a href="Writing-your-first-scripts.html#hello2">Example 1.2</a></dt><dd><p>Multiple lines</p></dd>
 <dt><a href="Writing-your-first-scripts.html#concatenateStrings">Example 1.3</a></dt><dd><p>Concatenate strings</p></dd>
@@ -190,7 +190,7 @@ the Sun</p></dd>
 <hr>
 <div class="header">
 <p>
-Next: <a href="The-Figures.html" accesskey="n" rel="next">The Figures</a>, Previous: <a href="Solutions-of-the-Exercises.html" accesskey="p" rel="prev">Solutions of the Exercises</a>, Up: <a href="index.html" accesskey="u" rel="up">Top</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
+Next: <a href="The-Figures.html" accesskey="n" rel="next">The Figures</a>, Previous: <a href="Solutions-to-the-Exercises.html" accesskey="p" rel="prev">Solutions to the Exercises</a>, Up: <a href="index.html" accesskey="u" rel="up">Top</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
 </div>
 
 

--- a/docs/The-Exercises.html
+++ b/docs/The-Exercises.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 
@@ -62,7 +62,7 @@ Complete license: https://creativecommons.org/licenses/by-sa/4.0/legalcode
 <link href="index.html" rel="start" title="Top">
 <link href="Indexes.html" rel="index" title="Indexes">
 <link href="index.html" rel="up" title="Top">
-<link href="Solutions-of-the-Exercises.html" rel="next" title="Solutions of the Exercises">
+<link href="Solutions-to-the-Exercises.html" rel="next" title="Solutions to the Exercises">
 <link href="Summary-of-Syntax.html" rel="prev" title="Summary of Syntax">
 <style type="text/css">
 <!--
@@ -90,7 +90,7 @@ ul.no-bullet {list-style: none}
 <body lang="en">
 <span id="The-Exercises"></span><div class="header">
 <p>
-Next: <a href="Solutions-of-the-Exercises.html" accesskey="n" rel="next">Solutions of the Exercises</a>, Previous: <a href="Summary-of-Syntax.html" accesskey="p" rel="prev">Summary of Syntax</a>, Up: <a href="index.html" accesskey="u" rel="up">Top</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
+Next: <a href="Solutions-to-the-Exercises.html" accesskey="n" rel="next">Solutions to the Exercises</a>, Previous: <a href="Summary-of-Syntax.html" accesskey="p" rel="prev">Summary of Syntax</a>, Up: <a href="index.html" accesskey="u" rel="up">Top</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
 </div>
 <hr>
 <span id="The-Exercises-1"></span><h2 class="appendix">Appendix C The Exercises</h2>
@@ -168,7 +168,7 @@ number</p></dd>
 <hr>
 <div class="header">
 <p>
-Next: <a href="Solutions-of-the-Exercises.html" accesskey="n" rel="next">Solutions of the Exercises</a>, Previous: <a href="Summary-of-Syntax.html" accesskey="p" rel="prev">Summary of Syntax</a>, Up: <a href="index.html" accesskey="u" rel="up">Top</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
+Next: <a href="Solutions-to-the-Exercises.html" accesskey="n" rel="next">Solutions to the Exercises</a>, Previous: <a href="Summary-of-Syntax.html" accesskey="p" rel="prev">Summary of Syntax</a>, Up: <a href="index.html" accesskey="u" rel="up">Top</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
 </div>
 
 

--- a/docs/The-Figures.html
+++ b/docs/The-Figures.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/The-Fundamentals-of-Morph-_0028Solutions_0029.html
+++ b/docs/The-Fundamentals-of-Morph-_0028Solutions_0029.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 
@@ -61,7 +61,7 @@ Complete license: https://creativecommons.org/licenses/by-sa/4.0/legalcode
 <meta name="Generator" content="texi2any">
 <link href="index.html" rel="start" title="Top">
 <link href="Indexes.html" rel="index" title="Indexes">
-<link href="Solutions-of-the-Exercises.html" rel="up" title="Solutions of the Exercises">
+<link href="Solutions-to-the-Exercises.html" rel="up" title="Solutions to the Exercises">
 <link href="Events-_0028Solutions_0029.html" rel="next" title="Events (Solutions)">
 <link href="Visual-with-Morph-_0028Solutions_0029.html" rel="prev" title="Visual with Morph (Solutions)">
 <style type="text/css">
@@ -90,7 +90,7 @@ ul.no-bullet {list-style: none}
 <body lang="en">
 <span id="The-Fundamentals-of-Morph-_0028Solutions_0029"></span><div class="header">
 <p>
-Next: <a href="Events-_0028Solutions_0029.html" accesskey="n" rel="next">Events (Solutions)</a>, Previous: <a href="Visual-with-Morph-_0028Solutions_0029.html" accesskey="p" rel="prev">Visual with Morph (Solutions)</a>, Up: <a href="Solutions-of-the-Exercises.html" accesskey="u" rel="up">Solutions of the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
+Next: <a href="Events-_0028Solutions_0029.html" accesskey="n" rel="next">Events (Solutions)</a>, Previous: <a href="Visual-with-Morph-_0028Solutions_0029.html" accesskey="p" rel="prev">Visual with Morph (Solutions)</a>, Up: <a href="Solutions-to-the-Exercises.html" accesskey="u" rel="up">Solutions to the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
 </div>
 <hr>
 <span id="The-Fundamentals-of-Morph-2"></span><h3 class="unnumberedsec">The Fundamentals of Morph</h3>
@@ -296,7 +296,7 @@ SpaceWar&gt;&gt;collisionsTorpedoesStar
 <hr>
 <div class="header">
 <p>
-Next: <a href="Events-_0028Solutions_0029.html" accesskey="n" rel="next">Events (Solutions)</a>, Previous: <a href="Visual-with-Morph-_0028Solutions_0029.html" accesskey="p" rel="prev">Visual with Morph (Solutions)</a>, Up: <a href="Solutions-of-the-Exercises.html" accesskey="u" rel="up">Solutions of the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
+Next: <a href="Events-_0028Solutions_0029.html" accesskey="n" rel="next">Events (Solutions)</a>, Previous: <a href="Visual-with-Morph-_0028Solutions_0029.html" accesskey="p" rel="prev">Visual with Morph (Solutions)</a>, Up: <a href="Solutions-to-the-Exercises.html" accesskey="u" rel="up">Solutions to the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
 </div>
 
 

--- a/docs/The-Fundamentals-of-Morph.html
+++ b/docs/The-Fundamentals-of-Morph.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/The-Image.html
+++ b/docs/The-Image.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/The-Message-Way-of-Life-_0028Solutions_0029.html
+++ b/docs/The-Message-Way-of-Life-_0028Solutions_0029.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 
@@ -61,7 +61,7 @@ Complete license: https://creativecommons.org/licenses/by-sa/4.0/legalcode
 <meta name="Generator" content="texi2any">
 <link href="index.html" rel="start" title="Top">
 <link href="Indexes.html" rel="index" title="Indexes">
-<link href="Solutions-of-the-Exercises.html" rel="up" title="Solutions of the Exercises">
+<link href="Solutions-to-the-Exercises.html" rel="up" title="Solutions to the Exercises">
 <link href="Class-_002d_002d-model-of-Communicating-Entities-_0028Solutions_0029.html" rel="next" title="Class -- model of Communicating Entities (Solutions)">
 <link href="Smallltalk-Philosophy-_0028Solutions_0029.html" rel="prev" title="Smallltalk Philosophy (Solutions)">
 <style type="text/css">
@@ -90,7 +90,7 @@ ul.no-bullet {list-style: none}
 <body lang="en">
 <span id="The-Message-Way-of-Life-_0028Solutions_0029"></span><div class="header">
 <p>
-Next: <a href="Class-_002d_002d-model-of-Communicating-Entities-_0028Solutions_0029.html" accesskey="n" rel="next">Class -- model of Communicating Entities (Solutions)</a>, Previous: <a href="Smallltalk-Philosophy-_0028Solutions_0029.html" accesskey="p" rel="prev">Smallltalk Philosophy (Solutions)</a>, Up: <a href="Solutions-of-the-Exercises.html" accesskey="u" rel="up">Solutions of the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
+Next: <a href="Class-_002d_002d-model-of-Communicating-Entities-_0028Solutions_0029.html" accesskey="n" rel="next">Class -- model of Communicating Entities (Solutions)</a>, Previous: <a href="Smallltalk-Philosophy-_0028Solutions_0029.html" accesskey="p" rel="prev">Smallltalk Philosophy (Solutions)</a>, Up: <a href="Solutions-to-the-Exercises.html" accesskey="u" rel="up">Solutions to the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
 </div>
 <hr>
 <span id="The-Message-Way-of-Life-2"></span><h3 class="unnumberedsec">The Message Way of Life</h3>

--- a/docs/The-Message-Way-of-Life.html
+++ b/docs/The-Message-Way-of-Life.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/The-Package.html
+++ b/docs/The-Package.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Understanding-Object-Oriented-Programming.html
+++ b/docs/Understanding-Object-Oriented-Programming.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Visual-with-Morph-_0028Solutions_0029.html
+++ b/docs/Visual-with-Morph-_0028Solutions_0029.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 
@@ -61,7 +61,7 @@ Complete license: https://creativecommons.org/licenses/by-sa/4.0/legalcode
 <meta name="Generator" content="texi2any">
 <link href="index.html" rel="start" title="Top">
 <link href="Indexes.html" rel="index" title="Indexes">
-<link href="Solutions-of-the-Exercises.html" rel="up" title="Solutions of the Exercises">
+<link href="Solutions-to-the-Exercises.html" rel="up" title="Solutions to the Exercises">
 <link href="The-Fundamentals-of-Morph-_0028Solutions_0029.html" rel="next" title="The Fundamentals of Morph (Solutions)">
 <link href="Control-Flow-Messaging-_0028Solutions_0029.html" rel="prev" title="Control Flow Messaging (Solutions)">
 <style type="text/css">
@@ -90,7 +90,7 @@ ul.no-bullet {list-style: none}
 <body lang="en">
 <span id="Visual-with-Morph-_0028Solutions_0029"></span><div class="header">
 <p>
-Next: <a href="The-Fundamentals-of-Morph-_0028Solutions_0029.html" accesskey="n" rel="next">The Fundamentals of Morph (Solutions)</a>, Previous: <a href="Control-Flow-Messaging-_0028Solutions_0029.html" accesskey="p" rel="prev">Control Flow Messaging (Solutions)</a>, Up: <a href="Solutions-of-the-Exercises.html" accesskey="u" rel="up">Solutions of the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
+Next: <a href="The-Fundamentals-of-Morph-_0028Solutions_0029.html" accesskey="n" rel="next">The Fundamentals of Morph (Solutions)</a>, Previous: <a href="Control-Flow-Messaging-_0028Solutions_0029.html" accesskey="p" rel="prev">Control Flow Messaging (Solutions)</a>, Up: <a href="Solutions-to-the-Exercises.html" accesskey="u" rel="up">Solutions to the Exercises</a> &nbsp; [<a href="Indexes.html" title="Index" rel="index">Index</a>]</p>
 </div>
 <hr>
 <span id="Visual-with-Morph-2"></span><h3 class="unnumberedsec">Visual with Morph</h3>

--- a/docs/Visual-with-Morph.html
+++ b/docs/Visual-with-Morph.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/Writing-your-first-scripts.html
+++ b/docs/Writing-your-first-scripts.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 
@@ -148,9 +148,10 @@ Transcript show: 'I am Cuising'
 </pre></div>
 
 <div class="float-caption"><p><strong>Example 1.2: </strong>Multiple lines</p></div></div>
-<p>In this three line script, observe how the lines are separated by a
-dot &ldquo;.&rdquo;. This period is a line separator so it is not needed in the third line
-nor in a one line script. The message <code>#newLine</code> has no argument.
+<p>In this three lines script, observe how the lines are separated by a
+dot &ldquo;.&rdquo;. This period is a line separator so it is not needed in the
+third line nor in a one line script. The message <code>#newLine</code> has no
+argument.
 </p>
 <span id="index-string"></span>
 <p>A <em>String</em> is the way text is represented in a programming

--- a/docs/accurateCollisionShipsSun.html
+++ b/docs/accurateCollisionShipsSun.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/addAfter.html
+++ b/docs/addAfter.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/allActorsMorph.html
+++ b/docs/allActorsMorph.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/alphabetCipher.html
+++ b/docs/alphabetCipher.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/apples12.html
+++ b/docs/apples12.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/askingClass.html
+++ b/docs/askingClass.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/blockDivisor.html
+++ b/docs/blockDivisor.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/breakpoint.html
+++ b/docs/breakpoint.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/capWordNumber.html
+++ b/docs/capWordNumber.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/categorizeControls.html
+++ b/docs/categorizeControls.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/categorizeTeleport.html
+++ b/docs/categorizeTeleport.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/centralStarDraw.html
+++ b/docs/centralStarDraw.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/centralStarExtent.html
+++ b/docs/centralStarExtent.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch00_002dimg1.html
+++ b/docs/ch00_002dimg1.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch01_002dPreferences.html
+++ b/docs/ch01_002dPreferences.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch01_002dSpacewarGameplay.html
+++ b/docs/ch01_002dSpacewarGameplay.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch01_002dSpacewarPDP.html
+++ b/docs/ch01_002dSpacewarPDP.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch01_002dimg1a.html
+++ b/docs/ch01_002dimg1a.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch01_002dimg2.html
+++ b/docs/ch01_002dimg2.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch02_002dInstalledPackages.html
+++ b/docs/ch02_002dInstalledPackages.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch02_002dbrowserDetailed.html
+++ b/docs/ch02_002dbrowserDetailed.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch02_002dspacewarClassCategory.html
+++ b/docs/ch02_002dspacewarClassCategory.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch03_002dbrowseHierarchy.html
+++ b/docs/ch03_002dbrowseHierarchy.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch03_002dbrowseProtocol.html
+++ b/docs/ch03_002dbrowseProtocol.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch03_002dfloatClassSide.html
+++ b/docs/ch03_002dfloatClassSide.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch03_002dfloatInstanceSide.html
+++ b/docs/ch03_002dfloatInstanceSide.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch05_002dSpacewarGamePlay.html
+++ b/docs/ch05_002dSpacewarGamePlay.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch06_002d01_002dEllipseMorphFromMenu.html
+++ b/docs/ch06_002d01_002dEllipseMorphFromMenu.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch06_002d03_002dDragToEnlarge.html
+++ b/docs/ch06_002d03_002dDragToEnlarge.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch06_002d04_002dEnlarged.html
+++ b/docs/ch06_002d04_002dEnlarged.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch06_002d05_002dAddRectangle.html
+++ b/docs/ch06_002d05_002dAddRectangle.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch06_002d06_002dEmbedRectIntoEllipse.html
+++ b/docs/ch06_002d06_002dEmbedRectIntoEllipse.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch06_002d07_002dMiddleClickRect.html
+++ b/docs/ch06_002d07_002dMiddleClickRect.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch06_002d08_002d2ndMidClckToSubmorph.html
+++ b/docs/ch06_002d08_002d2ndMidClckToSubmorph.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch06_002d09_002dMove_002dWithin.html
+++ b/docs/ch06_002d09_002dMove_002dWithin.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch06_002d10_002dPickUp_002d2_002dMoveOut.html
+++ b/docs/ch06_002d10_002dPickUp_002d2_002dMoveOut.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch06_002d11aColorClickOnRect.html
+++ b/docs/ch06_002d11aColorClickOnRect.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch06_002d12_002dInspectEllipse.html
+++ b/docs/ch06_002d12_002dInspectEllipse.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch06_002d14_002dSetBorderColor.html
+++ b/docs/ch06_002d14_002dSetBorderColor.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch06_002d15_002dColorClickEllipse.html
+++ b/docs/ch06_002d15_002dColorClickEllipse.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch06_002d20_002dTorpedoUpdateInheritance.html
+++ b/docs/ch06_002d20_002dTorpedoUpdateInheritance.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch07_002d01_002dLineDetails.html
+++ b/docs/ch07_002d01_002dLineDetails.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch07_002d02_002dTriangles.html
+++ b/docs/ch07_002d02_002dTriangles.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch07_002d03_002dAnimatedMorph.html
+++ b/docs/ch07_002d03_002dAnimatedMorph.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch07_002d04_002dAnimatedAndClippedSubmorph.html
+++ b/docs/ch07_002d04_002dAnimatedAndClippedSubmorph.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch07_002d05_002dClock.html
+++ b/docs/ch07_002d05_002dClock.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch07_002d06_002dExerciseClock.html
+++ b/docs/ch07_002d06_002dExerciseClock.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch07_002d07_002dClockMorph_002dinitialize.html
+++ b/docs/ch07_002d07_002dClockMorph_002dinitialize.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch07_002d08_002dClockMorph_002divars_002dadded.html
+++ b/docs/ch07_002d08_002dClockMorph_002divars_002dadded.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch07_002d09_002dfluctuatingStar.html
+++ b/docs/ch07_002d09_002dfluctuatingStar.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch07_002d10_002dShipDiagram.html
+++ b/docs/ch07_002d10_002dShipDiagram.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch07_002d11_002dTorpedoDiagram.html
+++ b/docs/ch07_002d11_002dTorpedoDiagram.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch07_002d12_002dbrowserClassSide.html
+++ b/docs/ch07_002d12_002dbrowserClassSide.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch07_002d13_002dshipDisplayBounds.html
+++ b/docs/ch07_002d13_002dshipDisplayBounds.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch08_002dFocus.html
+++ b/docs/ch08_002dFocus.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch10_002d01_002dZeroDivide.html
+++ b/docs/ch10_002d01_002dZeroDivide.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch10_002d02_002dDirChildNames.html
+++ b/docs/ch10_002d02_002dDirChildNames.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch10_002d03_002dDebugIt.html
+++ b/docs/ch10_002d03_002dDebugIt.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch10_002d04_002dStepInto.html
+++ b/docs/ch10_002d04_002dStepInto.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch10_002d05_002dFocusObjAndArgs.html
+++ b/docs/ch10_002d05_002dFocusObjAndArgs.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch10_002d06_002dHalt.html
+++ b/docs/ch10_002d06_002dHalt.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch10_002d07_002dOver.html
+++ b/docs/ch10_002d07_002dOver.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch10_002dAdd_002dRequirement.html
+++ b/docs/ch10_002dAdd_002dRequirement.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch10_002dBrowsePackageChange.html
+++ b/docs/ch10_002dBrowsePackageChange.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch10_002dChangeList.html
+++ b/docs/ch10_002dChangeList.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch10_002dChangeSet1.html
+++ b/docs/ch10_002dChangeSet1.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch10_002dChangeSet2.html
+++ b/docs/ch10_002dChangeSet2.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch10_002dChangeSetToCore.html
+++ b/docs/ch10_002dChangeSetToCore.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch10_002dFileListChangeSet.html
+++ b/docs/ch10_002dFileListChangeSet.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch10_002dImageSetUp.html
+++ b/docs/ch10_002dImageSetUp.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch10_002dNewPackage_002dMorphic_002dLearning.html
+++ b/docs/ch10_002dNewPackage_002dMorphic_002dLearning.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch10_002dPackage_002dwith_002drequirement.html
+++ b/docs/ch10_002dPackage_002dwith_002drequirement.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch10_002dRecoverLostChanges1.html
+++ b/docs/ch10_002dRecoverLostChanges1.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch10_002dRecoverLostChanges2.html
+++ b/docs/ch10_002dRecoverLostChanges2.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch10_002dSaved_002dwith_002drequirement.html
+++ b/docs/ch10_002dSaved_002dwith_002drequirement.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch11_002d01_002dSendersOfLeft.html
+++ b/docs/ch11_002d01_002dSendersOfLeft.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch11_002d02_002dRenameLeft.html
+++ b/docs/ch11_002d02_002dRenameLeft.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch11_002d03_002dRenameInCategory.html
+++ b/docs/ch11_002d03_002dRenameInCategory.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch11_002d04_002dturnLeft.html
+++ b/docs/ch11_002d04_002dturnLeft.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch11_002d05_002dnoseSenders.html
+++ b/docs/ch11_002d05_002dnoseSenders.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ch11_002d06_002dnoseDirection.html
+++ b/docs/ch11_002d06_002dnoseDirection.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/changeSetContents.html
+++ b/docs/changeSetContents.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/childNames.html
+++ b/docs/childNames.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/classInstanceVar.html
+++ b/docs/classInstanceVar.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/classVariableMobile.html
+++ b/docs/classVariableMobile.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/classesCount.html
+++ b/docs/classesCount.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/clockDialDrawing.html
+++ b/docs/clockDialDrawing.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/collFirst.html
+++ b/docs/collFirst.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/collectionAccess.html
+++ b/docs/collectionAccess.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/colorDict.html
+++ b/docs/colorDict.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/computeDivisors.html
+++ b/docs/computeDivisors.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/concatenateStrings.html
+++ b/docs/concatenateStrings.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/concatenateUppercase.html
+++ b/docs/concatenateUppercase.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/convertDynArray.html
+++ b/docs/convertDynArray.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/cosTable.html
+++ b/docs/cosTable.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/countingAncients.html
+++ b/docs/countingAncients.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/createArray.html
+++ b/docs/createArray.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/createOrderedColl.html
+++ b/docs/createOrderedColl.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/cubesCollect.html
+++ b/docs/cubesCollect.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/cutString.html
+++ b/docs/cutString.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/decodeCaesar.html
+++ b/docs/decodeCaesar.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/decodeCipher.html
+++ b/docs/decodeCipher.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/deleteMorphInstances.html
+++ b/docs/deleteMorphInstances.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/dynamicSize.html
+++ b/docs/dynamicSize.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/editMorphBehaviorInspector.html
+++ b/docs/editMorphBehaviorInspector.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/editShapeInspector.html
+++ b/docs/editShapeInspector.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/encodeCaesar.html
+++ b/docs/encodeCaesar.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ensure.html
+++ b/docs/ensure.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/entitiesCount.html
+++ b/docs/entitiesCount.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/exampleExample.html
+++ b/docs/exampleExample.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/exeAccurateDetection.html
+++ b/docs/exeAccurateDetection.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/exeCrossCenterMorph.html
+++ b/docs/exeCrossCenterMorph.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/exeCrossMorph.html
+++ b/docs/exeCrossMorph.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/exeDescribePackage.html
+++ b/docs/exeDescribePackage.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/exeDrawMobile.html
+++ b/docs/exeDrawMobile.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/exeFancyClock.html
+++ b/docs/exeFancyClock.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/exeFloatPrecision.html
+++ b/docs/exeFloatPrecision.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/exeFractionPrecision.html
+++ b/docs/exeFractionPrecision.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/exeNegativeIntegers.html
+++ b/docs/exeNegativeIntegers.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/exePlacement.html
+++ b/docs/exePlacement.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/exeRectMorph.html
+++ b/docs/exeRectMorph.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/exeRenameMethod.html
+++ b/docs/exeRenameMethod.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/exeRotateRect.html
+++ b/docs/exeRotateRect.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/exeSavePkgSpacewar.html
+++ b/docs/exeSavePkgSpacewar.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/exeSpaceShipClassSideDiagram.html
+++ b/docs/exeSpaceShipClassSideDiagram.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/exeTorpedoDrawing.html
+++ b/docs/exeTorpedoDrawing.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/exeTorpedoExtent.html
+++ b/docs/exeTorpedoExtent.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/exeZeroDivide.html
+++ b/docs/exeZeroDivide.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/exerciseExample.html
+++ b/docs/exerciseExample.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/fillArray.html
+++ b/docs/fillArray.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/fireTorpedo.html
+++ b/docs/fireTorpedo.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/firstShipControl.html
+++ b/docs/firstShipControl.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/floatInfo.html
+++ b/docs/floatInfo.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/forLoop.html
+++ b/docs/forLoop.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/formatString.html
+++ b/docs/formatString.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/goldberg1.html
+++ b/docs/goldberg1.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/gravityForce.html
+++ b/docs/gravityForce.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/gravityVector.html
+++ b/docs/gravityVector.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/handleMouseOver.html
+++ b/docs/handleMouseOver.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/hello.html
+++ b/docs/hello.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/hello2.html
+++ b/docs/hello2.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/helloBelle.html
+++ b/docs/helloBelle.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/helloCascade.html
+++ b/docs/helloCascade.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/holeSet.html
+++ b/docs/holeSet.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/ifTrueIfFalse.html
+++ b/docs/ifTrueIfFalse.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/implementingAndOr.html
+++ b/docs/implementingAndOr.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 
@@ -161,7 +161,7 @@ and efficient.
 </td></tr>
 <tr><td align="left" valign="top">&bull; <a href="The-Exercises.html">The Exercises</a></td><td>&nbsp;&nbsp;</td><td align="left" valign="top">
 </td></tr>
-<tr><td align="left" valign="top">&bull; <a href="Solutions-of-the-Exercises.html">Solutions of the Exercises</a></td><td>&nbsp;&nbsp;</td><td align="left" valign="top">
+<tr><td align="left" valign="top">&bull; <a href="Solutions-to-the-Exercises.html">Solutions to the Exercises</a></td><td>&nbsp;&nbsp;</td><td align="left" valign="top">
 </td></tr>
 <tr><td align="left" valign="top">&bull; <a href="The-Examples.html">The Examples</a></td><td>&nbsp;&nbsp;</td><td align="left" valign="top">
 </td></tr>
@@ -181,7 +181,7 @@ for the reviews of the book and suggestions to improve it.
 <br>
 </p>
 <br>
-<p>Compilation : January 31, 2021
+<p>Compilation : May 13, 2021
 </p>
 <p>Documentation source: <a href="https://github.com/Cuis-Smalltalk/TheCuisBook">https://github.com/Cuis-Smalltalk/TheCuisBook</a> 
 </p>

--- a/docs/initActors.html
+++ b/docs/initActors.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/initActorsCollections.html
+++ b/docs/initActorsCollections.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/initCentralStar.html
+++ b/docs/initCentralStar.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/initFullActors.html
+++ b/docs/initFullActors.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/initMobileHierarchy.html
+++ b/docs/initMobileHierarchy.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/initSpaceShip.html
+++ b/docs/initSpaceShip.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/initSpacewar.html
+++ b/docs/initSpacewar.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/initializeClass.html
+++ b/docs/initializeClass.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/instanceVariableMobileClass.html
+++ b/docs/instanceVariableMobileClass.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/integerBase.html
+++ b/docs/integerBase.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/integerBasicTest.html
+++ b/docs/integerBasicTest.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/interval.html
+++ b/docs/interval.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/intervalLoops.html
+++ b/docs/intervalLoops.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/inverseSum.html
+++ b/docs/inverseSum.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/keyboardEvent.html
+++ b/docs/keyboardEvent.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/keyboardFocusEffect.html
+++ b/docs/keyboardFocusEffect.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/methodConstant.html
+++ b/docs/methodConstant.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/methodTemplate.html
+++ b/docs/methodTemplate.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/mobileClass.html
+++ b/docs/mobileClass.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/mobileDeepSpace.html
+++ b/docs/mobileDeepSpace.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/mobileUpdate.html
+++ b/docs/mobileUpdate.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/morphProperties.html
+++ b/docs/morphProperties.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/motionEquations.html
+++ b/docs/motionEquations.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/mouseEnter.html
+++ b/docs/mouseEnter.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/mouseLeave.html
+++ b/docs/mouseLeave.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/multiples7.html
+++ b/docs/multiples7.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/multiplyBy1024.html
+++ b/docs/multiplyBy1024.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/nameColor.html
+++ b/docs/nameColor.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/negation.html
+++ b/docs/negation.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/newtonModel.html
+++ b/docs/newtonModel.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/oddNonPrime.html
+++ b/docs/oddNonPrime.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/oddNumbers.html
+++ b/docs/oddNumbers.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/playingDice.html
+++ b/docs/playingDice.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/prime100.html
+++ b/docs/prime100.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/qtyPrime100.html
+++ b/docs/qtyPrime100.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/qtyPrime200.html
+++ b/docs/qtyPrime200.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/refactoryShipTorpedo.html
+++ b/docs/refactoryShipTorpedo.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/reflreshGamePlay.html
+++ b/docs/reflreshGamePlay.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/remDelArray.html
+++ b/docs/remDelArray.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/repeatLoop.html
+++ b/docs/repeatLoop.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/roundingNumbers.html
+++ b/docs/roundingNumbers.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/secondShipControl.html
+++ b/docs/secondShipControl.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/selectApples.html
+++ b/docs/selectApples.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/setCollection.html
+++ b/docs/setCollection.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/setLetters.html
+++ b/docs/setLetters.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/setOpe.html
+++ b/docs/setOpe.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/setWithoutDuplicates.html
+++ b/docs/setWithoutDuplicates.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/shiftBits.html
+++ b/docs/shiftBits.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/shipAcceleration.html
+++ b/docs/shipAcceleration.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/shipCollision.html
+++ b/docs/shipCollision.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/shipControls.html
+++ b/docs/shipControls.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/shipHeading.html
+++ b/docs/shipHeading.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/shipLost.html
+++ b/docs/shipLost.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/shipSunCollision.html
+++ b/docs/shipSunCollision.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/shipsTorpedoesCollision.html
+++ b/docs/shipsTorpedoesCollision.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/signal.html
+++ b/docs/signal.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/simpleCipher.html
+++ b/docs/simpleCipher.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/simpleControls.html
+++ b/docs/simpleControls.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/spaceShipDrawing.html
+++ b/docs/spaceShipDrawing.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/spaceShipGetters.html
+++ b/docs/spaceShipGetters.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/spaceShipMechanic.html
+++ b/docs/spaceShipMechanic.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/spaceShipSetters.html
+++ b/docs/spaceShipSetters.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/spacewarKeyStroke.html
+++ b/docs/spacewarKeyStroke.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/spacewarVar.html
+++ b/docs/spacewarVar.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/squaredSum.html
+++ b/docs/squaredSum.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/stringArith.html
+++ b/docs/stringArith.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/teleportMethod.html
+++ b/docs/teleportMethod.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/teleportShip.html
+++ b/docs/teleportShip.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/teleportShipInterval.html
+++ b/docs/teleportShipInterval.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/torpedoClassVariables.html
+++ b/docs/torpedoClassVariables.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/torpedoMechanic.html
+++ b/docs/torpedoMechanic.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/torpedoOrientation.html
+++ b/docs/torpedoOrientation.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/torpedoSunCollision.html
+++ b/docs/torpedoSunCollision.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/twoCategoriesOnePackage.html
+++ b/docs/twoCategoriesOnePackage.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/updateShipVelocity.html
+++ b/docs/updateShipVelocity.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/updateShipsTorpedoes.html
+++ b/docs/updateShipsTorpedoes.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/vectorGraphicsNo.html
+++ b/docs/vectorGraphicsNo.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/docs/verticesMethod.html
+++ b/docs/verticesMethod.html
@@ -13,7 +13,7 @@ for the reviews of the book and suggestions to improve it.
 
 
 
-Compilation : January 31, 2021
+Compilation : May 13, 2021
 
 Documentation source: https://github.com/Cuis-Smalltalk/TheCuisBook 
 

--- a/en/TheCuisBook.texinfo
+++ b/en/TheCuisBook.texinfo
@@ -97,7 +97,7 @@ You are reading the Cuis Book!
 * Documents Copyright::
 * Summary of Syntax::
 * The Exercises::
-* Solutions of the Exercises::
+* Solutions to the Exercises::
 * The Examples::
 * The Figures::
 * Indexes::

--- a/en/chapter-00/contents.texinfo
+++ b/en/chapter-00/contents.texinfo
@@ -64,14 +64,14 @@ The reader can study @cuis{} from two versions of the book:
 
 @itemize
 
- @item @strong{Online.} With a web browser at the
+ @item @strong{Online:} With a web browser at the
  @url{https://cuis-smalltalk.github.io/TheCuisBook} address. The book
  is structured in chapters and sections, displayed one at a time. It
  is a very flexible way to study the book: you can open several
  chapters and appendices on different tabs in your web browser. It
  requires you to be connected to the Internet, though.
 
- @item @strong{Offline.} In a single PDF file you download and read
+ @item @strong{Offline:} In a single PDF file you download and read
  offline. It can be printed as a nice paper book. The most recent
  build can be found at @url{https://github.com/Cuis-Smalltalk/TheCuisBook}.
 
@@ -81,9 +81,9 @@ The reader can study @cuis{} from two versions of the book:
 @cindex variable @subentry assignment
 @cindex assignment @seeentry{variable}
 
-The chapters come with many examples. Some can be copied and pasted in
-@cuis{}, we encourage you to do this, and in the process modify them
-to explore by yourself.
+The chapters come with many examples. Some can be copied and pasted into
+@cuis{}. We encourage you to do this, and in the process modify them
+to explore on your own.
 
 The code examples in the online version can be directly copied and
 pasted into @cuis{}. This is why the assignment character ``@U{2190}''
@@ -95,15 +95,15 @@ In the offline PDF version, the code examples are printed with the same
 assignment and return characters as seen in the @cuis{} windows. Copying
 and pasting also work as expected.
 
-Other examples are code extracts which are notself sufficient to be
-executed as is; their purpose is to expose specific facets of the Smalltalk
+Other examples are code extracts which are not self sufficient to be
+executed as is. Their purpose is to expose specific facets of the Smalltalk
 language.
 
 A typical example without a caption looks like:
 
 @smalltalkExample{100 factorial}
 
-The same example with a caption comes with a number, a legend and it
+The same example with a caption appears with a number, a legend, and it
 can be used as a reference elsewhere in the book:
 
 @smalltalkExampleCaption{I am an example with a caption and a result, exampleExample,
@@ -115,13 +115,13 @@ can be used as a reference elsewhere in the book:
 There are also a lot of exercises. Most are very easy; they intend to give you
 an opportunity to apply what you have just learned.
 
-Exercises are easily identified, they are presented with the @cuis{}
-mascot: @dfn{Cuis}, a South American rodent!
+Exercises are easily identified with the @cuis{} mascot: @dfn{Cuis},
+a South American rodent!
 
 @exercise{I am an example of an exercise,exerciseExample,
 @emph{Search the Internet: How many versions of Smalltalk are there?}}
 
-The solutions to the exercises are presented in @ref{Solutions of the
+The solutions to the exercises are presented in @ref{Solutions to the
 Exercises}.
 
 Happy reading!

--- a/en/chapter-00/contents.texinfo
+++ b/en/chapter-00/contents.texinfo
@@ -103,7 +103,7 @@ A typical example without a caption looks like:
 
 @smalltalkExample{100 factorial}
 
-The same example with a caption appears with a number, a legend, and it
+The same example with a caption appears with a number and title, and
 can be used as a reference elsewhere in the book:
 
 @smalltalkExampleCaption{I am an example with a caption and a result, exampleExample,

--- a/en/chapter-00/contents.texinfo
+++ b/en/chapter-00/contents.texinfo
@@ -19,13 +19,13 @@ is, and what it means to build software. As a consequence, Cuis is
 especially effective if these ideas resonate with you and, at least
 occasionally, you let them guide your thoughts and actions.
 
-In this book, we will go along with you as you explore, discover and
+In this book, we will accompany you as you explore, discover and
 learn about Cuis and Smalltalk.
 
 We don't assume knowledge of computer programming, but if you happen
-to have some experience with an Object Oriented or Functional language
+to have some experience with an Object-Oriented or Functional language
 you will recognize many concepts. If you don't have any programming
-experience, or you have coded in an imperative, closer to the metal
+experience or you have coded in an imperative, closer to the metal
 language, such as C or Assembly, many of the ideas may be new.
 
 In any case, especially during the first chapters, read this book and
@@ -36,25 +36,24 @@ programming is a thoughtful process.
 We understand software development as the activity of learning and
 documenting knowledge for ourselves and others to use, and also to be
 run on a computer. The fact that a computer can execute the software
-and produce useful solutions to some problem, is a consequence of the
+and produce useful solutions to some problem is a consequence of the
 knowledge being sound and relevant. Just making it work is not the
 important part!
 
-These ideas, that will be developed further along in the book you are
-reading, strongly shape Cuis and the experience of using it.  Amongst
-their most obvious consequences are a passion for reducing unneeded
-complexity, while providing a complete, live software development
-experience.
+These ideas strongly shape Cuis and the experience of using it, and
+we'll develop them further along in this book.  Amongst their most
+obvious consequences are a passion for reducing unneeded complexity,
+while providing a complete, live software development experience.
 
 This book is an introduction and invitation to explore Cuis.  We hope
 you will join us in this journey to use Cuis as a medium to express
-ideas and thoughts, to build cool stuff, and to make Cuis ever better.
+ideas and thoughts, to build cool stuff, and to make Cuis even better.
 
 @figure{Cuis,ch00-img1,12}
 
 To make your journey with this book more enjoyable, the
 @emph{Spacewar!}@footnote{@url{https://en.wikipedia.org/wiki/Spacewar!}}
-project is its recurring theme. It is distilled along the book in code
+project is its recurring theme. It is distilled into the book in code
 examples, exercises and dedicated chapters. At the end of the book,
 you will have written a replica of this historic video game.
 
@@ -72,31 +71,33 @@ The reader can study @cuis{} from two versions of the book:
  chapters and appendices on different tabs in your web browser. It
  requires you to be connected to the Internet, though.
 
- @item @strong{Offline.} It is a PDF version coming in one file you
- download and read offline. It can be printed as a nice paper
- book. Its most recent build is found at
- @url{https://github.com/Cuis-Smalltalk/TheCuisBook}.
+ @item @strong{Offline.} In a single PDF file you download and read
+ offline. It can be printed as a nice paper book. The most recent
+ build can be found at @url{https://github.com/Cuis-Smalltalk/TheCuisBook}.
 
 @end itemize
 
 @cindex returned value
 @cindex variable @subentry assignment
 @cindex assignment @seeentry{variable}
+
+The chapters come with many examples. Some can be copied and pasted in
+@cuis{}, we encourage you to do this, and in the process modify them
+to explore by yourself.
+
 The code examples in the online version can be directly copied and
 pasted into @cuis{}. This is why the assignment character ``@U{2190}''
 you see in the developer @cuis{} window is printed as ``:='' in the
 online version of the book. The same applies with the return character
 ``@U{2191}'' printed as ``^'' in the online version.
 
-In the offline PDF version, the code example are printed with the same
- assignment and return characters as seen in the @cuis{}
- windows. Coping and pasting also work as expected.
+In the offline PDF version, the code examples are printed with the same
+assignment and return characters as seen in the @cuis{} windows. Copying
+and pasting also work as expected.
 
-The chapters come with many examples. Some can be copied and pasted in
-@cuis{}, we encourage you to do this, and in the process modify them
-to explore by yourself. Other examples are code extracts which are not
-self sufficient to be executed as is; their purpose is to expose
-specific facets of the Smalltalk language.
+Other examples are code extracts which are notself sufficient to be
+executed as is; their purpose is to expose specific facets of the Smalltalk
+language.
 
 A typical example without a caption looks like:
 
@@ -105,23 +106,22 @@ A typical example without a caption looks like:
 The same example with a caption comes with a number, a legend and it
 can be used as a reference elsewhere in the book:
 
-@smalltalkExampleCaption{I am an example with a caption and result, exampleExample,
+@smalltalkExampleCaption{I am an example with a caption and a result, exampleExample,
 100 factorial
 @result{}  9332621544394415268169923885626670049071596826438162146859
 29638952175999932299156089414639761565182862536979208272237582
 51185210916864000000000000000000000000}
 
-There are also a lot of exercises. Most are very
-easy, their intent is to give you an opportunity to apply what was
-learned just before. The solution can be read in the appendix.
+There are also a lot of exercises. Most are very easy; they intend to give you
+an opportunity to apply what you have just learned.
 
-Exercises are easily identified, there are presented by the @cuis{}
+Exercises are easily identified, they are presented with the @cuis{}
 mascot: @dfn{Cuis}, a South American rodent!
 
 @exercise{I am an example of an exercise,exerciseExample,
 @emph{Search the Internet: How many versions of Smalltalk are there?}}
 
-The solution of the exercises are presented in @ref{Solutions of the
+The solutions to the exercises are presented in @ref{Solutions of the
 Exercises}.
 
 Happy reading!

--- a/en/chapter-00/contents.texinfo
+++ b/en/chapter-00/contents.texinfo
@@ -115,7 +115,7 @@ can be used as a reference elsewhere in the book:
 There are also a lot of exercises. Most are very easy; they intend to give you
 an opportunity to apply what you have just learned.
 
-Exercises are easily identified with the @cuis{} mascot: @dfn{Cuis},
+Exercises are easily identified by the @cuis{} mascot: @dfn{Cuis},
 a South American rodent!
 
 @exercise{I am an example of an exercise,exerciseExample,

--- a/en/chapter-07/contents.texinfo
+++ b/en/chapter-07/contents.texinfo
@@ -234,7 +234,7 @@ We will learn how to control all this with code and animate our morph.
 around one corner? If necessary rewrite your rectangle morph so it rotates
 around its center.}}
 
-In the solution we gave for the @ref{exeCrossMorph} (@ref{Solutions of
+In the solution we gave for the @ref{exeCrossMorph} (@ref{Solutions to
 the Exercises}), the cross origin is set to its top left. Therefore it
 rotates around this point.
 

--- a/en/chapter-50/contents.texinfo
+++ b/en/chapter-50/contents.texinfo
@@ -1,6 +1,6 @@
-@c Solution of the exercises
-@node Solutions of the Exercises
-@appendix Solutions of the Exercises
+@c Solutions to the exercises
+@node Solutions to the Exercises
+@appendix Solutions to the Exercises
 
 
 @menu


### PR DESCRIPTION
Fixes some typos in the Preface, one which required cascading changes to references to "Solutions to the Exercises" (changed from "Solutions of the Exercises").