### PR TITLE
clarifications on strings

### DIFF
--- a/docs/Message-to-string-entities.html
+++ b/docs/Message-to-string-entities.html
@@ -99,11 +99,10 @@ Next: <a href="Messages-to-number-entities.html" accesskey="n" rel="next">Messag
 <span id="index-string-4"></span>
 
 <p><strong>Note.</strong> We wrote earlier a string is a collection of
-characters. It is true for byte string, where each character is
-encoded with a byte &ndash; a byte string. However since 2023, the default
-string format for Cuis-Smalltalk is Unicode (UTF-8) where each character can
-be encoded with 1, 2, 3 or 4 bytes. Therefore it is immutable and can
-not be indexed, it can be converted as byte string with the message
+characters. There are 2 types  of strings in Cuis: byte strings and Unicode (UTF-8) strings, the latter being the default since 2023.  
+ In a byte string,  each character is encoded with a byte &ndash. In an Unicode string each character can
+be encoded with 1, 2, 3 or 4 bytes. It is immutable and can
+not be indexed, but it can be converted to byte string with the message
 <code>#asByteString</code>.
 </p>
 <p>Access to a character in a string is done with the keyword message
@@ -111,7 +110,7 @@ not be indexed, it can be converted as byte string with the message
 the following examples with the <kbd>Ctrl-p</kbd> shortcut:
 </p>
 <div class="example">
-<pre class="example">'Hello' at: 1 &rArr; $H
+<pre class="example">'Hello' at: 1 &rArr;  $H(000048) 
 'Hello' asByteString at: 5 &rArr; $o
 </pre></div>
 
@@ -122,7 +121,7 @@ string length.
 </p>
 <span id="index-string-5"></span>
 <div class="example">
-<pre class="example">'Hello' asByeString indexOf: $e
+<pre class="example">'Hello' asByteString indexOf: $e
 &rArr; 2
 </pre></div>
 


### PR DESCRIPTION
IMO the sentences in note contained unnecessary complication, as strings are always collections (sequences) of characters , regardless of encoding.  Removed "Therefore" before "it is immutable and cannot be indexed", because being UTF-8 does not imply those, strictly speaking. Also when I ran the Ist example, 
'Hello' at: 1.  
my Cuis produced $H(000048) , not just $H ,so edited the ex accordingly.

And a question: why say that it cannot be indexed, if (the new UTF8) strings can still receive the message 'at: ' and 'indexOf', even without using 'asByteString' ?  Perhaps it will not work correctly for all strings? If so, maybe say "not all strings will be indexed correctly"? And specify indexing will work correctly if the string is made up of ASCII characters , I guess ?...

But in general, concerning the language: I believe all this is internal implementation detail that should not concern the users of Cuis. Or else, it goes against the simplicity and cleanliness tradition of Smalltalk, no?  The new strings should be able to correctly receive #at and  #indexOf , as well as be changed using 'at: put:' etc, without having to be converted to byte strings first (or at least not by the user, explicitely).  Having to use #asBytestring so often is a nuisance.