### PR TITLE
Fix typos in code examples of chapter 4

### DIFF
--- a/docs/Collections-detailed.html
+++ b/docs/Collections-detailed.html
@@ -170,7 +170,7 @@ array1 at: 2 &rArr; 'Apple'
 array2 at: 3 &rArr; 2@3
 array2 swap: 2 with: 4 &rArr; #(2 1/3 2@3 'Apple') 
 array1 at: 2 put: 'Orange'; yourself &rArr; #(2 'Orange' $@ 4)
-array1 indexOf: 'Orange &rArr; 2
+array1 indexOf: 'Orange' &rArr; 2
 </pre></div>
 <div class="caption"><p><strong class="strong">Example 4.10: </strong>Collection access to elements</p></div></div>
 <p>Use the System Browser to discover alternative ways to access elements
@@ -362,7 +362,7 @@ dictionary:
 </p>
 <div class="example smallexample">
 <pre class="example-preformatted">colors associationsDo: [:assoc | 
-   Transcript show: assoc key; space; assoc value; cr ]
+   Transcript show: assoc key; space; show: assoc value; cr ]
 </pre></div>
 
 <p>There are other variants to explore by yourself.

--- a/en/chapter-04/contents.texinfo
+++ b/en/chapter-04/contents.texinfo
@@ -628,7 +628,7 @@ array1 at: 2 @result{} 'Apple'
 array2 at: 3 @result{} 2@@3
 array2 swap: 2 with: 4 @result{} #(2 1/3 2@@3 'Apple') 
 array1 at: 2 put: 'Orange'; yourself @result{} #(2 'Orange' $@@ 4)
-array1 indexOf: 'Orange @result{} 2}
+array1 indexOf: 'Orange' @result{} 2}
 
 Use the System Browser to discover alternative ways to access elements
 of a collection.
@@ -780,7 +780,7 @@ dictionary:
 Sometimes, you really need to iterate the whole key-value association:
 
 @smalltalkExample{colors associationsDo: [:assoc | 
-   Transcript show: assoc key; space; assoc value; cr ]}
+   Transcript show: assoc key; space; show: assoc value; cr ]}
 
 There are other variants to explore by yourself.
 


### PR DESCRIPTION
* Add a close quote to an array example
* Add `show:` to an associationsDo dictionary cascade