### PR TITLE
Update click sequence label in contents.texinfo

### DIFF
--- a/en/chapter-02/contents.texinfo
+++ b/en/chapter-02/contents.texinfo
@@ -532,7 +532,7 @@ pane.
 With the mouse pointer over the class category pane of the Browser --
 the left-most one -- just do:
 
-...@clicksequence{right mouse click @click{} @label{add item}}... then
+...@clicksequence{right mouse click @click{} @label{Add Category}}... then
 key in @emph{Spacewar!}
 
 


### PR DESCRIPTION
"add-item..." menu entry in Cuis 5.x was correct but at least in Cuis 7.6 it changed to "Add Category..."